### PR TITLE
Propose this to avoid compilation errors on Cygwin / R 4.6.0

### DIFF
--- a/src/dist.c
+++ b/src/dist.c
@@ -280,7 +280,7 @@ static void romberg2(void fcn(), double *a, double *b, int len,
 		    int pts, int max, int *err, double sumlen[])
 {
   int i,j,j1,finish;
-  double errsum,*tab1,*tab2,*x,*fx,*sum,*tmpsum,*zz,*pnt1,*pnt2,*y;
+  double errsum=0.,*tab1,*tab2,*x,*fx,*sum,*tmpsum,*zz,*pnt1,*pnt2,*y;
 
   x=(double*)R_alloc((size_t)(max*len),sizeof(double));
   fx=(double*)R_alloc((size_t)(max*len),sizeof(double));


### PR DESCRIPTION
This is the error that occurs when trying to compile rmutil with R 4.6.0
==
dist.c: In function ‘romberg2’:
dist.c:309:5: warning: ‘errsum’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  if(fabs(errsum)>eps*fabs(sumlen[i]))finish=0;}
     ^~~~~~~~~~~~
==